### PR TITLE
feat: type-level domain check

### DIFF
--- a/app/[locale]/PodcastDirectoryLink.tsx
+++ b/app/[locale]/PodcastDirectoryLink.tsx
@@ -7,51 +7,68 @@ import Link from 'next/link'
 import { useMemo } from 'react'
 
 type DirectoryInfo = {
-  icon: React.ComponentType<{ className?: string }>
   label: string
+  domains: readonly string[]
+  icon: React.ComponentType<{ className?: string }>
 }
-const directoryMapper: { [key: string]: DirectoryInfo } = {
-  '(?:spotify.com|open.spotify.com)': {
-    icon: SpotifyIcon,
+
+type SupportedDomains = (typeof directoryMapper)[number]['domains'][number]
+export type SupportedDirectory = `https://${
+  | 'www.'
+  | ''}${SupportedDomains}/${string}`
+
+export const directoryMapper = [
+  {
     label: 'Spotify',
+    domains: ['spotify.com', 'open.spotify.com'],
+    icon: SpotifyIcon,
   },
-  '(?:apple.co|podcasts.apple.com)': {
-    icon: ApplePodcastIcon,
+  {
     label: 'Apple Podcasts',
+    domains: ['apple.co', 'podcasts.apple.com'],
+    icon: ApplePodcastIcon,
   },
-  '(?:google.com|podcasts.google.com)': {
-    icon: GooglePodcastIcon,
+  {
     label: 'Google Podcasts',
+    domains: ['google.com', 'podcasts.google.com'],
+    icon: GooglePodcastIcon,
   },
-  '(?:overcast.fm)': {
-    icon: OvercastIcon,
+  {
     label: 'Overcast',
+    domains: ['overcast.fm'],
+    icon: OvercastIcon,
   },
-  '(?:stitcher.com)': {
-    icon: StitcherIcon,
+  {
     label: 'Stitcher',
+    domains: ['stitcher.com'],
+    icon: StitcherIcon,
   },
-  '(?:pocketcasts.com|pca.st)': {
-    icon: PocketCastsIcon,
+  {
     label: 'Pocket Casts',
+    domains: ['pocketcasts.com', 'pca.st'],
+    icon: PocketCastsIcon,
   },
-  '(?:castro.fm)': {
-    icon: CastroIcon,
+  {
     label: 'Castro',
+    domains: ['castro.fm'],
+    icon: CastroIcon,
   },
-  '(?:xiaoyuzhoufm.com)': {
-    icon: XiaoYuZhouFMIcon,
+  {
     label: '小宇宙',
+    domains: ['xiaoyuzhoufm.com'],
+    icon: XiaoYuZhouFMIcon,
   },
-  '(?:youtube.com|youtu.be)': {
-    icon: YouTubeIcon,
+  {
     label: 'YouTube',
+    domains: ['youtube.com', 'youtu.be'],
+    icon: YouTubeIcon,
   },
-  '(?:bilibili.com|b23.tv)': {
-    icon: BiliBiliIcon,
+  {
     label: '哔哩哔哩',
+    domains: ['bilibili.com', 'b23.tv'],
+    icon: BiliBiliIcon,
   },
-}
+] as const satisfies readonly DirectoryInfo[]
 
 export function PodcastDirectoryLink({
   children,
@@ -67,10 +84,10 @@ export function PodcastDirectoryLink({
       return { icon: RSSIcon, label: 'RSS' }
     }
 
-    const directory = Object.entries(directoryMapper).find(([key]) =>
-      children.match(key)
+    const directory = directoryMapper.find((d) =>
+      children.match(new RegExp(`(?:${d.domains.join('|')})`, 'i'))
     )
-    return directory ? directory[1] : null
+    return directory
   }, [children, isRSS])
 
   return (

--- a/app/app.d.ts
+++ b/app/app.d.ts
@@ -4,11 +4,6 @@ type RootParams = { locale: 'en' | 'zh-CN' }
 type Messages = typeof import('~/messages/en.json')
 declare interface IntlMessages extends Messages {}
 
-type PodcastConfig = {
-  directories: string[]
-  hosts: Host[]
-}
-
 type Podcast = {
   title: string
   description: string

--- a/podcast.config.ts
+++ b/podcast.config.ts
@@ -1,6 +1,13 @@
 import { cache } from 'react'
 import { parse } from 'rss-to-json'
 
+import type { SupportedDirectory } from './app/[locale]/PodcastDirectoryLink'
+
+type PodcastConfig = {
+  directories: SupportedDirectory[]
+  hosts: Host[]
+}
+
 /**
  * TODO: Add your podcast config here
  */


### PR DESCRIPTION
## Why

Directory URLs aren't checked at compile time, and invalid ones result in gaps in the UI. While supported platforms are documented in the comment, it's still unclear which domains are supported without looking at the code. Editor hints will be helpful.
<img width="400" alt="image" src="https://github.com/CaliCastle/cali-fm/assets/43892874/b64822d0-7866-45d1-8649-cab528460f26">

## Before
`directories` is `string[]`, so any input string is allowed, no type check.

```ts
type PodcastConfig = {
  directories: string[]
  hosts: Host[]
}
```
## After
Read supported domains from `directoryMapper` at type level, so we can get editor hints immediately for invalid ones.

<img width="400" alt="image" src="https://github.com/CaliCastle/cali-fm/assets/43892874/446fd59b-6f66-4ab0-8a73-9414a6e6b069">


## Playground link
https://tsplay.dev/podcast-domains
